### PR TITLE
Fix GitHub Actions permissions for auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,13 +10,16 @@ jobs:
   create-release:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
     
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
       
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Add explicit permissions for GitHub Actions to push commits and tags
- Configure workflow to use PAT_TOKEN if available, with GITHUB_TOKEN fallback
- Fixes the 403 permission denied error when auto-release tries to push version bumps

## Problem
The auto-release workflow was failing with:
```
remote: Permission to chasedut/toke.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/chasedut/toke/': The requested URL returned error: 403
```

## Solution
1. Added explicit `permissions` block granting `contents: write` and `pull-requests: read`
2. Modified token usage to prefer `PAT_TOKEN` if configured, falling back to `GITHUB_TOKEN`

## Test plan
- [ ] Merge a PR to develop branch
- [ ] Verify auto-release workflow runs successfully
- [ ] Confirm version bump commit is pushed
- [ ] Check that release tag is created

🤖 Generated with [Claude Code](https://claude.ai/code)