### PR TITLE
Fix TUI initial sizing and improve model selection UX

### DIFF
--- a/internal/tui/components/dialogs/commands/commands.go
+++ b/internal/tui/components/dialogs/commands/commands.go
@@ -309,16 +309,16 @@ func (c *commandDialogCmp) defaultCommands() []Command {
 		},
 		{
 			ID:          "switch_model",
-			Title:       "Switch Model",
-			Description: "Switch to a different model",
+			Title:       "Choose Cloud Model",
+			Description: "Configure API providers and switch cloud models",
 			Handler: func(cmd Command) tea.Cmd {
 				return util.CmdHandler(SwitchModelMsg{})
 			},
 		},
 		{
 			ID:          "add_new_models",
-			Title:       "New Model",
-			Description: "Download local models or configure API providers",
+			Title:       "Choose Local Model",
+			Description: "Download and use local models",
 			Handler: func(cmd Command) tea.Cmd {
 				return util.CmdHandler(AddNewModelsMsg{})
 			},

--- a/internal/tui/components/dialogs/models/add.go
+++ b/internal/tui/components/dialogs/models/add.go
@@ -77,17 +77,7 @@ func (m *AddModelsCmp) buildOptions() []list.Group[list.CompletionItem[AddOption
 	)
 	quickGroup.Items = append(quickGroup.Items, recommendedItem)
 
-	// Add API setup
-	apiItem := list.NewCompletionItem(
-		"🔑 Setup API Provider",
-		AddOption{
-			Type:        "setup_api",
-			Title:       "Setup API Provider",
-			Description: "Configure OpenAI, Anthropic, or other cloud providers",
-		},
-		list.WithCompletionID("quick:api"),
-	)
-	quickGroup.Items = append(quickGroup.Items, apiItem)
+	// Removed API setup - moved to command palette
 
 	groups = append(groups, quickGroup)
 
@@ -259,10 +249,6 @@ func (m *AddModelsCmp) handleSelection(option AddOption) (tea.Model, tea.Cmd) {
 		// Switch to the download dialog
 		return m, util.CmdHandler(dialogs.OpenDialogMsg{Model: backendDialog})
 
-	case "setup_api":
-		// Open the regular model switcher which has API setup
-		return m, util.CmdHandler(dialogs.OpenDialogMsg{Model: NewModelDialogCmp()})
-
 	case "browse_hf":
 		// Open the new HF Browse dialog as a modal
 		hfDialog := NewHFBrowseCmp()
@@ -305,16 +291,13 @@ func (m *AddModelsCmp) View() string {
 			}
 			
 			content.WriteString(cursor)
-			content.WriteString(itemStyle.Render(item.Text()))
 			
-			// Show description for selected item
-			if itemIdx == m.selectedIdx && item.Value().Description != "" {
-				descStyle := lipgloss.NewStyle().
-					Foreground(m.theme.FgHalfMuted).
-					MarginLeft(4)
-				content.WriteString("\n")
-				content.WriteString(descStyle.Render(item.Value().Description))
+			// Format as "Model - Description" on same line
+			displayText := item.Text()
+			if item.Value().Description != "" {
+				displayText = fmt.Sprintf("%s - %s", item.Text(), item.Value().Description)
 			}
+			content.WriteString(itemStyle.Render(displayText))
 			
 			content.WriteString("\n")
 			itemIdx++

--- a/internal/tui/components/dialogs/models/models.go
+++ b/internal/tui/components/dialogs/models/models.go
@@ -85,7 +85,8 @@ func NewModelDialogCmp() ModelDialog {
 	listKeyMap.UpOneItem = keyMap.Previous
 
 	t := styles.CurrentTheme()
-	modelList := NewModelListComponent(listKeyMap, "Choose a model for large, complex tasks", true)
+	modelList := NewModelListComponent(listKeyMap, "Choose a cloud model for large, complex tasks", true)
+	modelList.excludeLocal = true // Exclude local models from this dialog
 	apiKeyInput := NewAPIKeyInput()
 	apiKeyInput.SetShowTitle(false)
 	help := help.New()
@@ -287,7 +288,7 @@ func (m *modelDialogCmp) View() string {
 	radio := m.modelTypeRadio()
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,
-		t.S().Base.Padding(0, 1, 1, 1).Render(core.Title("Switch Model", m.width-lipgloss.Width(radio)-5)+" "+radio),
+		t.S().Base.Padding(0, 1, 1, 1).Render(core.Title("Choose Cloud Model", m.width-lipgloss.Width(radio)-5)+" "+radio),
 		listView,
 		"",
 		t.S().Base.Width(m.width-2).PaddingLeft(1).AlignHorizontal(lipgloss.Left).Render(m.help.View(m.keyMap)),

--- a/internal/tui/loading/simple.go
+++ b/internal/tui/loading/simple.go
@@ -26,6 +26,12 @@ func NewSimple() *SimpleLoadingScreen {
 	}
 }
 
+// SetSize sets the initial dimensions
+func (l *SimpleLoadingScreen) SetSize(width, height int) {
+	l.width = width
+	l.height = height
+}
+
 // Init initializes the loading screen
 func (l *SimpleLoadingScreen) Init() tea.Cmd {
 	return animateSimple()
@@ -49,9 +55,13 @@ func (l *SimpleLoadingScreen) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View renders the simple loading screen
 func (l *SimpleLoadingScreen) View() string {
+	// Don't render if we don't have dimensions yet
 	if l.width == 0 || l.height == 0 {
 		return ""
 	}
+	
+	width := l.width
+	height := l.height
 	
 	// ASCII art for TOKE
 	asciiArt := []string{
@@ -110,8 +120,8 @@ func (l *SimpleLoadingScreen) View() string {
 	finalContent := content.String()
 	
 	return lipgloss.Place(
-		l.width,
-		l.height,
+		width,
+		height,
 		lipgloss.Center,
 		lipgloss.Center,
 		finalContent,

--- a/toke-tauri/src-tauri/tauri.conf.json
+++ b/toke-tauri/src-tauri/tauri.conf.json
@@ -28,9 +28,7 @@
       "signingIdentity": null
     },
     "resources": [
-      "../../build/toke-darwin-arm64/**/*",
-      "../../build/toke-darwin-amd64/**/*", 
-      "../../build/toke-windows-amd64/**/*"
+      "../../build/toke-darwin-arm64/**/*"
     ],
     "shortDescription": "",
     "targets": "all",


### PR DESCRIPTION
## Summary
- Fixed terminal size detection to eliminate UI flash on startup
- Improved model selection dialogs with better UX
- Fixed MLX model downloads from Hugging Face

## Changes

### TUI Initial Sizing Fix
- Added proper terminal size detection using `term.GetSize()` before initializing the TUI
- Pass initial dimensions to the TUI model to prevent rendering with zero width/height
- Prevent rendering until proper dimensions are known
- Loading screen now uses actual terminal dimensions from the start

### Model Selection Improvements
- **Inline descriptions**: Model descriptions now appear on the same line (e.g., "Model Name - Description") instead of on separate lines
- **MLX model handling**: When selecting an MLX model from Hugging Face, it now automatically downloads all necessary files instead of showing a file picker
- **Clearer menu labels**:
  - "Switch Model" → "Choose Cloud Model" 
  - "Add New Models" → "Choose Local Model"
- **Separated local/cloud models**: Cloud model dialog no longer shows local models
- **Removed redundant items**: Eliminated duplicate "Setup API Provider" option

### Other Fixes
- Fixed Tauri build configuration by removing references to non-existent binary paths
- Reduced loading screen duration from 1.5s to 0.5s for snappier startup

## Test Plan
- [x] Run `toke` from command line - no size flashing on startup
- [x] Test model selection dialogs - descriptions appear inline
- [x] Select an MLX model from Hugging Face - downloads all files automatically
- [x] Check command palette - new labels are clear and no redundant items
- [x] Build Tauri app - no build errors

🤖 Generated with [Claude Code](https://claude.ai/code)